### PR TITLE
Add param -v to install a specific version using xahaud-install-update.sh

### DIFF
--- a/xahaud-install-update.sh
+++ b/xahaud-install-update.sh
@@ -128,28 +128,28 @@ if [[ "$FIRST_RUN" == true ]]; then
   echo "This script has been copied to /usr/local/bin and can be invoked without a path."
 fi
 
-log "Fetching latest version of $PROGRAM..."
+log "Fetching versions of $PROGRAM..."
 filenames=$(curl --silent "${URL}" | grep -Eo '>[^<]+<' | sed -e 's/^>//' -e 's/<$//' | grep -E '^\S+\+[0-9]{2,3}$' | grep -E $RELEASE_TYPE)
 
-latest_file=$(curl https://build.xahau.tech/ 2>/dev/null | grep release | grep -v releaseinfo | sed -E 's/(<a href[^>]*?>).*/\1/g' | sed -E 's/(^[^"]+"|"[^"]+$)//g' | sort -t'B' -k2n -n | tail -n 1)
+version_file=$(curl https://build.xahau.tech/ 2>/dev/null | grep release | grep -v releaseinfo | sed -E 's/(<a href[^>]*?>).*/\1/g' | sed -E 's/(^[^"]+"|"[^"]+$)//g' | sort -t'B' -k2n -n | tail -n 1)
 
 
-log "$latest_file is the latest available for download"
-if [[ -f "$DL_DIR/$latest_file" ]]; then
-    log "File already downloaded: $latest_file"
+log "$version_file is available for download"
+if [[ -f "$DL_DIR/$version_file" ]]; then
+    log "File already downloaded: $version_file"
 else
-    log "Downloading latest file: ${latest_file} to $DL_DIR"
-    curl --silent --fail "${URL}${latest_file}" -o "$DL_DIR/$latest_file"
+    log "Downloading version file: ${version_file} to $DL_DIR"
+    curl --silent --fail "${URL}${version_file}" -o "$DL_DIR/$version_file"
 fi
 
-chmod +x "$DL_DIR/$latest_file"
-chown $USER:$USER "$DL_DIR/$latest_file"
+chmod +x "$DL_DIR/$version_file"
+chown $USER:$USER "$DL_DIR/$version_file"
 
-# Update symlink if the latest file is different from the one it points to
+# Update symlink if the version file is different from the one it points to
 current_file=$(readlink "$BIN_DIR/$PROGRAM")
-if [[ "$current_file" != "$DL_DIR/$latest_file" ]]; then
-    log "Updating symlink: $current_file -> $DL_DIR/$latest_file"
-    ln -snf "$DL_DIR/$latest_file" "$BIN_DIR/$PROGRAM"
+if [[ "$current_file" != "$DL_DIR/$version_file" ]]; then
+    log "Updating symlink: $current_file -> $DL_DIR/$version_file"
+    ln -snf "$DL_DIR/$version_file" "$BIN_DIR/$PROGRAM"
     DO_RESTART=true
 else
     DO_RESTART=false
@@ -308,7 +308,7 @@ fi
 ln -snf $BIN_DIR/$PROGRAM /usr/local/bin/$PROGRAM
 
 if [[ "$DO_RESTART" == true ]]; then
-  log "New version of $PROGRAM installed $latest_file."
+  log "New version of $PROGRAM installed $version_file."
   log "Please restart by running the following ..."
   log "systemctl stop $PROGRAM.service"
   log "systemctl start $PROGRAM.service"


### PR DESCRIPTION
Changes:
- renamed variable `latest_file` to `version_file`
- removed word "latest" in various comments and outputs
- added param `-v` to install a specific version (eg. "-v 2023.12.29-release+689")

The default behavior without specifing `-v` remains identical. If `-v` is omitted, the latest version is installed.

Tested on Ubuntu 22, RedHat 9.3:
- previous behavior (`-v` omitted) remains identical and installs latest version
- specifing-v installs a speicifc version
- script exits with code 1 if a specified version is not found